### PR TITLE
Util+Simulation: Implement dates using C/C++ standard library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,6 +57,8 @@ add_executable(
 
     src/pyssa/Environment.cpp
     src/pyssa/Object.cpp
+
+    src/util/SimulationClock.cpp
 )
 
 target_link_libraries(

--- a/src/Object.cpp
+++ b/src/Object.cpp
@@ -33,7 +33,7 @@ Object::Object(World& world, double mass, double radius, Vector3 pos, Vector3 ve
     , m_color(color)
     , m_name(name)
     , m_orbit_len(period)
-    , m_creation_date(world.date().get_int()) {
+    , m_creation_date(world.date()) {
     m_trail.push_back(m_pos);
     m_sphere.set_color(m_color);
 }
@@ -94,40 +94,32 @@ void Object::update(int speed) {
         m_vel = entry.vel;
     }
 
-    if(m_world.date().new_day()){
-        if (speed > 0)
-            m_history.push_back({ m_pos, m_vel });
-        else if (speed < 0)
-            m_history.push_front();
+    if (speed > 0)
+        m_history.push_back({ m_pos, m_vel });
+    else if (speed < 0)
+        m_history.push_front();
 
-        if (!m_most_attracting_object || m_is_forward_simulated) {
-            m_trail.recalculate_with_offset({});
-            m_trail.push_back(m_pos);
-            return;
-        }
+    if (!m_most_attracting_object || m_is_forward_simulated) {
+        m_trail.recalculate_with_offset({});
+        m_trail.push_back(m_pos);
+        return;
+    }
 
-        if (m_most_attracting_object != m_old_most_attracting_object)
-            m_trail.recalculate_with_offset(m_most_attracting_object->m_pos);
-        else
-            m_trail.set_offset(m_most_attracting_object->m_pos);
-        m_trail.push_back(m_pos - m_most_attracting_object->m_pos);
+    if (m_most_attracting_object != m_old_most_attracting_object)
+        m_trail.recalculate_with_offset(m_most_attracting_object->m_pos);
+    else
+        m_trail.set_offset(m_most_attracting_object->m_pos);
+    m_trail.push_back(m_pos - m_most_attracting_object->m_pos);
 
-        double distance_from_object = get_distance(this->m_pos, m_most_attracting_object->m_pos);
-        if (m_ap < distance_from_object) {
-            m_ap = distance_from_object;
-            m_ap_vel = m_vel.magnitude();
-        }
+    double distance_from_object = get_distance(this->m_pos, m_most_attracting_object->m_pos);
+    if (m_ap < distance_from_object) {
+        m_ap = distance_from_object;
+        m_ap_vel = m_vel.magnitude();
+    }
 
-        if (m_pe > distance_from_object) {
-            m_pe = distance_from_object;
-            m_pe_vel = m_vel.magnitude();
-        }
-    }else{ 
-        if(m_history.on_edge())
-            m_history.change_current({m_pos, m_vel});
-
-        if(m_most_attracting_object != nullptr)
-            m_trail.change_current(m_pos - m_most_attracting_object->m_pos);
+    if (m_pe > distance_from_object) {
+        m_pe = distance_from_object;
+        m_pe_vel = m_vel.magnitude();
     }
 }
 

--- a/src/Object.hpp
+++ b/src/Object.hpp
@@ -8,6 +8,7 @@
 #include "math/Vector3.hpp"
 #include "pyssa/Object.hpp"
 #include "pyssa/WrappedObject.hpp"
+#include "util/SimulationClock.hpp"
 #include <SFML/Graphics/Color.hpp>
 #include <SFML/Graphics/RenderWindow.hpp>
 #include <limits>
@@ -49,7 +50,7 @@ public:
 
     double mass() const { return m_gravity_factor / G; }
     double gravity_factor() const { return m_gravity_factor; }
-    int creation_date() const { return m_creation_date; }
+    Util::SimulationClock::time_point creation_date() const { return m_creation_date; }
 
     static void setup_python_bindings(TypeSetup);
     static constexpr char const* PythonClassName = "Object";
@@ -68,7 +69,7 @@ public:
 
         // Only if orbiting around more massive object.
         double distance_from_most_massive_object = 0; // in AU
-        double apogee = 0; // in AU
+        double apogee = 0;                            // in AU
         double apogee_velocity = 0;
         double perigee = 0; // in AU
         double perigee_velocity = 0;
@@ -113,7 +114,7 @@ private:
 
     bool m_is_forward_simulated = false;
     Sphere m_sphere;
-    int m_creation_date;
+    Util::SimulationClock::time_point m_creation_date;
     Vector3 m_vel;
     std::string m_name;
     sf::Color m_color;

--- a/src/ObjectHistory.cpp
+++ b/src/ObjectHistory.cpp
@@ -1,11 +1,12 @@
 #include "ObjectHistory.hpp"
+#include "util/SimulationClock.hpp"
 
 void ObjectHistory::clear_history(unsigned long to_index) {
     m_entries.resize(std::min(to_index, m_entries.size()));
     m_pos = to_index - 1;
 }
 
-bool ObjectHistory::set_time(unsigned int time) {
+bool ObjectHistory::set_time(Util::SimulationClock::time_point time) {
     m_pos = m_entries.size();
 
     for (auto& e : m_entries) {

--- a/src/ObjectHistory.hpp
+++ b/src/ObjectHistory.hpp
@@ -14,7 +14,7 @@ public:
 
     unsigned get_pos() const { return m_pos; }
     void clear_history(unsigned long to_index);
-    bool set_time(unsigned time);
+    bool set_time(Util::SimulationClock::time_point time);
 
     void push_to_entry(std::unique_ptr<Object> obj);
     std::unique_ptr<Object> pop_from_entries();

--- a/src/SimulationView.cpp
+++ b/src/SimulationView.cpp
@@ -303,7 +303,7 @@ void SimulationView::draw(sf::RenderWindow& window) const {
     }
 
     std::ostringstream oss;
-    oss << m_world.date().to_full_date_string();
+    oss << m_world.date();
     if (m_speed == 0)
         oss << " (Paused";
     else

--- a/src/World.hpp
+++ b/src/World.hpp
@@ -3,9 +3,10 @@
 #include "Constants.hpp"
 #include "Object.hpp"
 #include "ObjectHistory.hpp"
-#include "math/Vector3.hpp"
 #include "gui/Date.hpp"
+#include "math/Vector3.hpp"
 #include "pyssa/WrappedObject.hpp"
+#include "util/SimulationClock.hpp"
 
 #include <SFML/Graphics.hpp>
 #include <cstdint>
@@ -30,7 +31,7 @@ public:
     void reset();
     Object* get_object_by_name(std::string const& name);
 
-    Date date() const{return m_date;}
+    Util::SimulationClock::time_point date() const { return m_date; }
 
     template<class C>
     void for_each_object(C callback) {
@@ -42,18 +43,19 @@ public:
 
     int simulation_seconds_per_tick() const { return m_simulation_seconds_per_tick; }
     void set_simulation_seconds_per_tick(int s) { m_simulation_seconds_per_tick = s; }
-    
+
     void reset_all_trails();
 
     static void setup_python_bindings(TypeSetup);
     static constexpr char const* PythonClassName = "World";
 
 private:
-    Date m_date;
+    Util::SimulationClock::time_point m_date;
     ObjectHistory m_object_history;
     std::list<std::unique_ptr<Object>> m_object_list;
     int m_simulation_seconds_per_tick = 60 * 60 * 12; // 12 Hours / half a day
     bool m_is_forward_simulated = false;
+    bool m_should_add_history_entry;
 
     // FIXME: (on WrappedObject side) Allow const-qualified members
     PySSA::Object python_get_object_by_name(PySSA::Object const& args);

--- a/src/util/SimulationClock.cpp
+++ b/src/util/SimulationClock.cpp
@@ -1,0 +1,32 @@
+#include "SimulationClock.hpp"
+
+std::ostream& operator<<(std::ostream& out, Util::SimulationClock::time_point const& time) {
+    auto time_as_time_t = time.time_since_epoch().count();
+    
+    tm* time_as_tm = gmtime(&time_as_time_t);
+
+    char buffer[256];
+    strftime(buffer, 256, "%Y-%m-%d %H:%M:%S", time_as_tm);
+    out << buffer;
+    return out;
+}
+
+namespace Util::SimulationTime {
+
+SimulationClock::time_point create(int year, int month, int day, int hour, int minute, int second) {
+    tm time {
+        .tm_sec = second,
+        .tm_min = minute,
+        .tm_hour = hour,
+        .tm_mday = day,
+        .tm_mon = month - 1,
+        .tm_year = year - 1900,
+        .tm_wday = 0,
+        .tm_yday = 0,
+        .tm_isdst = 0,
+    };
+    auto time_epoch = mktime(&time);
+    return SimulationClock::time_point(SimulationClock::duration(time_epoch));
+}
+
+}

--- a/src/util/SimulationClock.hpp
+++ b/src/util/SimulationClock.hpp
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <chrono>
+#include <ctime>
+#include <iostream>
+#include <ratio>
+
+namespace Util {
+
+class SimulationClock {
+public:
+    using rep = time_t;
+    using period = std::ratio<1, 1>; // 1 second
+    using duration = std::chrono::duration<rep, period>;
+    using time_point = std::chrono::time_point<SimulationClock>;
+};
+
+namespace SimulationTime {
+
+// This expects data in human-readable units
+// E.g if you want to create 1970-02-15 you call create(1920, 2, 15, 0, 0, 0).
+// Maybe it is obvious but C library uses another format.
+SimulationClock::time_point create(int year, int month, int day, int hour = 0, int minute = 0, int second = 0);
+
+}
+
+// We need at least 8 bytes to represent our simulation times!
+static_assert(sizeof(time_t) == 8);
+
+}
+
+std::ostream& operator<<(std::ostream& out, Util::SimulationClock::time_point const& time);


### PR DESCRIPTION
Assuming that the C standard library can handle 64-bit times, we can
use their help instead of manually implementing date-time conversion.

This commit implements custom Clock that is compatible with std::chrono
types. This makes doing date operations pretty straightforward.